### PR TITLE
Support for 0-latency gates

### DIFF
--- a/libtoqm/libtoqm/CostFunc/CXFrontier.hpp
+++ b/libtoqm/libtoqm/CostFunc/CXFrontier.hpp
@@ -53,11 +53,11 @@ public:
 					temp = sg->gate->controlChild;
 				}
 				
-				while(temp && temp->control < 0) {
+				while(temp && temp->control < 0) { // keha: add optimistic latency of all contiguous single qubit gates
 					pathLength[actualQubit] += temp->optimisticLatency;
 					temp = temp->targetChild;
 				}
-				next2BitGate[actualQubit] = temp;
+				next2BitGate[actualQubit] = temp; // keha: after loop, we must be at next 2q gate, or end of the line
 			}
 		}
 		
@@ -79,7 +79,7 @@ public:
 						pathLength[physicalTarget] = 1;//since we won't schedule any more gates this cycle
 					}
 					GateNode * temp = g;
-					while(temp && temp->control < 0) {
+					while(temp && temp->control < 0) { // keha: add optimistic latency of all contiguous single qubit gates
 						pathLength[physicalTarget] += temp->optimisticLatency;
 						temp = temp->targetChild;
 					}

--- a/libtoqm/libtoqm/Expander/DefaultExpander.hpp
+++ b/libtoqm/libtoqm/Expander/DefaultExpander.hpp
@@ -237,7 +237,7 @@ public:
 				if(x & (1LL << y)) {
 					if(node->cycle >= -1) {
 						good = good && child->scheduleGate(possibleGates[y]);
-					} else {
+					} else {//keha: should we assert that this is a swap gate?
 						good = good && child->swapQubits(possibleGates[y]->target, possibleGates[y]->control);
 					}
 				}

--- a/libtoqm/libtoqm/Latency/Table.hpp
+++ b/libtoqm/libtoqm/Latency/Table.hpp
@@ -93,7 +93,10 @@ private:
 		for (const auto & e : entries) {
 			
 			//Don't allow entries where physical qubits are only partially specified:
-			assert(e.numQubits < 2 || (e.target != -1 && e.control != -1));
+			assert(e.numQubits < 2 || (e.target != -1 && e.control != -1) || e.target == e.control);
+
+			// keha: 0-latency swaps are not supported.
+			assert(!(e.type == "swap" || e.type == "SWAP") || e.latency > 0);
 			
 			//Don't allow duplicate entries
 			auto latenciesKey = LatencyTableKey {e.type, e.numQubits, e.target, e.control};

--- a/libtoqm/libtoqm/Node.cpp
+++ b/libtoqm/libtoqm/Node.cpp
@@ -5,6 +5,7 @@
 #include <set>
 #include <cassert>
 #include <iostream>
+#include <string>
 
 namespace toqm {
 
@@ -24,14 +25,17 @@ Node::Node(Environment& environment) : env(environment) {
 
 Node::~Node() = default;
 
+bool isSwapGate(const GateNode * gate) {
+	return gate->name == "swap" || gate->name == "SWAP";
+}
+
 //schedule a gate, or return false if it conflicts with an active gate
 //the gate parameter uses logical qubits (except in swaps); this function determines physical locations based on prior swaps
 //the timeOffset can be used if we want to schedule a gate to start X cycles in the future
 //this function adjusts qubit map when scheduling a swap
 bool Node::scheduleGate(GateNode* gate, unsigned int timeOffset) {
-	bool isSwap = !gate->name.compare("swap");
-	isSwap = isSwap || !gate->name.compare("swap");
-	
+	bool isSwap = isSwapGate(gate);
+
 	int physicalControl = gate->control;
 	int physicalTarget = gate->target;
 	if(!isSwap) {
@@ -42,7 +46,7 @@ bool Node::scheduleGate(GateNode* gate, unsigned int timeOffset) {
 			physicalTarget = laq[physicalTarget];
 		}
 	}
-	
+
 	int busyControl = this->busyCycles(physicalControl);
 	if(physicalControl >= 0 && busyControl > 0 && busyControl > (int) timeOffset) {
 		return false;
@@ -51,16 +55,34 @@ bool Node::scheduleGate(GateNode* gate, unsigned int timeOffset) {
 	if(physicalTarget >= 0 && busyTarget > 0 && busyTarget > (int) timeOffset) {
 		return false;
 	}
-	
+
+	this->scheduleGate(gate, physicalTarget, physicalControl, timeOffset);
+	return true;
+}
+
+/**
+ * Schedule gate on the designated physical target and control bits at the designated offset.
+ * Scheduling validation is NOT performed!
+ * @param gate
+ * @param physicalTarget
+ * @param physicalControl
+ * @param timeOffset
+ */
+void Node::scheduleGate(GateNode* gate, int physicalTarget, int physicalControl, unsigned int timeOffset) {
+	bool isSwap = isSwapGate(gate);
+
+	std::vector<GateNode *> unblockedGates {};
+	unblockedGates.reserve(2);
+
 	if(!isSwap) {
 		//if appropriate, add double-child to ready gates
 		if(gate->controlChild && gate->controlChild == gate->targetChild) {
-			readyGates.insert(gate->controlChild);
+			unblockedGates.push_back(gate->controlChild);
 		}
 		//if appropriate, add control child to ready gates
 		if(gate->controlChild && gate->controlChild != gate->targetChild) {
 			if(gate->controlChild->control < 0) {//single-qubit gate
-				readyGates.insert(gate->controlChild);
+				unblockedGates.push_back(gate->controlChild);
 			} else {
 				int childParentBit;
 				GateNode * otherParent;
@@ -82,14 +104,14 @@ bool Node::scheduleGate(GateNode* gate, unsigned int timeOffset) {
 				}
 				if(childParentBit < 0 || (this->lastNonSwapGate[childParentBit] &&
 										  this->lastNonSwapGate[childParentBit]->gate == otherParent)) {
-					readyGates.insert(gate->controlChild);
+					unblockedGates.push_back(gate->controlChild);
 				}
 			}
 		}
 		//if appropriate, add target child to ready gates
 		if(gate->targetChild && gate->controlChild != gate->targetChild) {
 			if(gate->targetChild->control < 0) {//single-qubit gate
-				readyGates.insert(gate->targetChild);
+				unblockedGates.push_back(gate->targetChild);
 			} else {
 				int childParentBit;
 				GateNode * otherParent;
@@ -111,7 +133,7 @@ bool Node::scheduleGate(GateNode* gate, unsigned int timeOffset) {
 				}
 				if(childParentBit < 0 || (this->lastNonSwapGate[childParentBit] &&
 										  this->lastNonSwapGate[childParentBit]->gate == otherParent)) {
-					readyGates.insert(gate->targetChild);
+					unblockedGates.push_back(gate->targetChild);
 				}
 			}
 		}
@@ -162,8 +184,55 @@ bool Node::scheduleGate(GateNode* gate, unsigned int timeOffset) {
 		}
 		std::swap(qal[physicalControl], qal[physicalTarget]);
 	}
-	
-	return true;
+
+	// keha: add unblocked gates to ready gates and schedule any 0-duration gates immediately
+	for (GateNode * gn : unblockedGates) {
+		readyGates.insert(gn);
+
+		if (isSwapGate(gn)) {
+			// Skip swaps. 0-latency swaps aren't supported since nodes
+			// can only have a single LAQ/QAL mapping.
+			continue;
+		}
+
+		// Determine if this newly unblocked gate should be scheduled immediately
+		// in the current cycle.
+		auto gnPhysicalControl = gn->control >= 0 ? laq[gn->control] : -1;
+		auto gnPhysicalTarget = laq[gn->target];
+		auto latency = env.latency.getLatency(gn->name, gnPhysicalControl >= 0 ? 2 : 1, gnPhysicalTarget, gnPhysicalControl);
+
+		// Special case for cycle == 0.
+		// In the 0th cycle only, the unblocked gate's bits might only
+		// have 0-duration gates scheduled on them so far.
+		// In that case, we should always schedule it immediately even
+		// if it has a non-zero duration, else it'll incorrectly end
+		// up in cycle 1.
+		bool emptyFirstCycles = true;
+		if (cycle == 0) {
+			// Determine if a non-zero duration instruction has already been scheduled
+			// on these bits.
+			auto sgs = scheduled.get();
+			while (sgs->value) {
+				auto usesControl = gnPhysicalControl >= 0 && (sgs->value->physicalControl == gnPhysicalControl || sgs->value->physicalTarget == gnPhysicalControl);
+				auto usesTarget = sgs->value->physicalControl == gnPhysicalTarget || sgs->value->physicalTarget == gnPhysicalTarget;
+
+				if ((usesControl || usesTarget) && sgs->value->cycle == 0 && sgs->value->latency > 0) {
+					emptyFirstCycles = false;
+					break;
+				}
+
+				sgs = sgs->next.get();
+			}
+		} else {
+			emptyFirstCycles = false;
+		}
+
+		if (latency == 0 || emptyFirstCycles) {
+			// 0-latency gate, or 0th cycle special case.
+			// Recursively schedule this gate in the same cycle as the gate that unblocked it.
+			this->scheduleGate(gn, gnPhysicalTarget, gnPhysicalControl, timeOffset);
+		}
+	}
 }
 
 //prepares a new child node (without scheduling any more gates)

--- a/libtoqm/libtoqm/Node.hpp
+++ b/libtoqm/libtoqm/Node.hpp
@@ -81,6 +81,9 @@ public:
 	
 	//prepares a new child node (without scheduling any more gates)
 	static std::unique_ptr<Node> prepChild(const std::shared_ptr<Node>& parent);
+
+private:
+	void scheduleGate(GateNode* gate, int physicalTarget, int physicalControl, unsigned int timeOffset);
 };
 
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -87,27 +87,6 @@ private:
 	}
 };
 
-std::vector<toqm::GateOp> gates = {
-		toqm::GateOp(0, "cx", 0, 1),
-		toqm::GateOp(1, "cx", 0, 2),
-		toqm::GateOp(2, "cx", 0, 4),
-		toqm::GateOp(3, "cx", 1, 2),
-		toqm::GateOp(4, "cx", 1, 4),
-		toqm::GateOp(5, "cx", 2, 4)
-};
-
-auto coupling_map = toqm::CouplingMap {
-		7,
-		{
-				{0, 1},
-				{1, 2},
-				{2, 3},
-				{3, 4},
-				{4, 5},
-				{5, 6},
-		}
-};
-
 namespace toqm {
 bool operator==(ScheduledGateOp const & lhs, ScheduledGateOp const & rhs) {
 	return std::tie(lhs.cycle, lhs.latency, lhs.physicalControl, lhs.physicalTarget) ==
@@ -116,6 +95,27 @@ bool operator==(ScheduledGateOp const & lhs, ScheduledGateOp const & rhs) {
 }
 
 TEST_CASE("Latency table can be configured to behave like simple latencies.", "[latency]") {
+	std::vector<toqm::GateOp> gates = {
+			toqm::GateOp(0, "cx", 0, 1),
+			toqm::GateOp(1, "cx", 0, 2),
+			toqm::GateOp(2, "cx", 0, 4),
+			toqm::GateOp(3, "cx", 1, 2),
+			toqm::GateOp(4, "cx", 1, 4),
+			toqm::GateOp(5, "cx", 2, 4)
+	};
+
+	auto coupling_map = toqm::CouplingMap {
+			7,
+			{
+					{0, 1},
+					{1, 2},
+					{2, 3},
+					{3, 4},
+					{4, 5},
+					{5, 6},
+			}
+	};
+
 	std::vector<toqm::LatencyDescription> latencies {};
 
 	for (int x = 0; x < 7; x++) {
@@ -156,4 +156,89 @@ TEST_CASE("Latency table can be configured to behave like simple latencies.", "[
 	//printNode(std::cout, table_result->scheduledGates);
 
 	REQUIRE(std::equal(simple_result->scheduledGates.begin(), simple_result->scheduledGates.end(), table_result->scheduledGates.begin()));
+}
+
+TEST_CASE("Test 0-latency instructions work as expected.", "[latency]") {
+	auto coupling_map = toqm::CouplingMap {
+			3,
+			{
+					{0, 1},
+					{1, 2},
+			}
+	};
+
+	std::vector<toqm::GateOp> gates = {
+			toqm::GateOp(0, "cx", 0, 1),
+			toqm::GateOp(1, "rz", 1),
+			toqm::GateOp(2, "cx", 1, 0),
+	};
+
+	std::vector<toqm::LatencyDescription> latencies {};
+
+	latencies.emplace_back(1, "rz", 0);
+	latencies.emplace_back(2, "cx", 2);
+	//latencies.emplace_back("cx", 1, 0, 1);
+	latencies.emplace_back(2, "swap", 6);
+
+	auto table = std::unique_ptr<toqm::Latency>(new toqm::Table(latencies));
+
+	MapperBuilder mapper{};
+	mapper.Latency = std::move(table);
+
+	auto result = mapper.build()->run(gates, coupling_map.numPhysicalQubits, coupling_map, 0);
+
+	// Require order is the same, since this is the only valid ordering for this circuit.
+	REQUIRE(result->scheduledGates[0].gateOp.uid == 0);
+	REQUIRE(result->scheduledGates[1].gateOp.uid == 1);
+	REQUIRE(result->scheduledGates[2].gateOp.uid == 2);
+
+	// Require 0-duration RZ happens in the same cycle as first CX.
+	REQUIRE(result->scheduledGates[0].cycle == 0);
+	REQUIRE(result->scheduledGates[1].cycle == 0);
+	REQUIRE(result->scheduledGates[2].cycle == 2);
+}
+
+TEST_CASE("Test 0-latency instructions at start of circuit.", "[latency]") {
+	auto coupling_map = toqm::CouplingMap {
+			3,
+			{
+					{0, 1},
+					{1, 2},
+			}
+	};
+
+	std::vector<toqm::GateOp> gates = {
+			toqm::GateOp(0, "rz", 1),
+			toqm::GateOp(1, "rz", 1),
+			toqm::GateOp(2, "cx", 0, 1),
+			toqm::GateOp(3, "cx", 1, 0),
+	};
+
+	std::vector<toqm::LatencyDescription> latencies {};
+
+	latencies.emplace_back(1, "rz", 0);
+	latencies.emplace_back(2, "cx", 2);
+	//latencies.emplace_back("cx", 1, 0, 1);
+	latencies.emplace_back(2, "swap", 6);
+
+	auto table = std::unique_ptr<toqm::Latency>(new toqm::Table(latencies));
+
+	MapperBuilder mapper{};
+	mapper.Latency = std::move(table);
+
+	auto result = mapper.build()->run(gates, coupling_map.numPhysicalQubits, coupling_map, 0);
+
+	printNode(std::cout, result->scheduledGates);
+
+	// Require order is the same, since this is the only valid ordering for this circuit.
+	REQUIRE(result->scheduledGates[0].gateOp.uid == 0);
+	REQUIRE(result->scheduledGates[1].gateOp.uid == 1);
+	REQUIRE(result->scheduledGates[2].gateOp.uid == 2);
+	REQUIRE(result->scheduledGates[3].gateOp.uid == 3);
+
+	// Require 0-duration RZ happens in the same cycle as first CX.
+	REQUIRE(result->scheduledGates[0].cycle == 0);
+	REQUIRE(result->scheduledGates[1].cycle == 0);
+	REQUIRE(result->scheduledGates[2].cycle == 0);
+	REQUIRE(result->scheduledGates[3].cycle == 2);
 }


### PR DESCRIPTION
Adds support for 0-latency 1 and 2 qubit gates, with the exception of `swap` gates, which must still be of a non-zero duration. This change was made to support instructions like `RZ` on IBM hardware, which is considered to execute instantaneously.

Prior to this change, 0-latency gates caused `libtoqm` to crash.

To support such gates, `Node::scheduleGate` has been changed to immediately schedule any subsequent 0-latency gates that become unblocked (all qubit data dependencies satisfied) as a result of scheduling the given gate. This is recursive for consecutive 0-latency gates.