### PR TITLE
Fix issues with zero latency gates

### DIFF
--- a/libtoqm/libtoqm/Expander/DefaultExpander.hpp
+++ b/libtoqm/libtoqm/Expander/DefaultExpander.hpp
@@ -120,7 +120,10 @@ public:
 			
 			if(good) {
 				int latency = node->env.latency.getLatency(g->name, (control >= 0 ? 2 : 1), target, control);
-				if(latency == 1) {
+				// keha: added latency == 0 to support case when 0-latency
+				// gate is at front of circuit or couldn't be scheduled immediately mid-circuit
+				// due to incompatible current layout.
+				if(latency == 1 || latency == 0) {
 					singleCycleGates.push_back(g);
 				} else {
 					possibleGates.push_back(g);

--- a/libtoqm/libtoqm/Latency/Table.hpp
+++ b/libtoqm/libtoqm/Latency/Table.hpp
@@ -10,6 +10,8 @@
 #include <utility>
 #include <tuple>
 #include <iostream>
+#include <sstream>
+#include <exception>
 
 namespace toqm {
 
@@ -153,9 +155,12 @@ public:
 		}
 		
 		//Crash
-		std::cerr << "FATAL ERROR: could not find any valid latency for specified " << gateName << " gate.\n";
-		std::cerr << "\t" << numQubits << "\t" << gateName << "\t" << target << "\t" << control << "\n";
-		exit(1);
+		std::stringstream ss;
+		ss << "FATAL ERROR: could not find any valid latency for specified " << gateName << " gate.\n";
+		ss << "\t" << numQubits << "\t" << gateName << "\t" << target << "\t" << control << "\n";
+		std::cerr << ss.str();
+		
+		throw std::runtime_error(ss.str());
 	}
 	
 	std::unique_ptr<Latency> clone() const override {

--- a/libtoqm/libtoqm/Node.hpp
+++ b/libtoqm/libtoqm/Node.hpp
@@ -53,10 +53,12 @@ public:
 	
 	ScheduledGate* lastNonSwapGate[MAX_QUBITS]{};//last scheduled non-swap gate per LOGICAL qubit
 	ScheduledGate* lastGate[MAX_QUBITS]{};//last scheduled gate per PHYSICAL qubit
+	ScheduledGate* lastNonZeroLatencyGate[MAX_QUBITS]{};//last non-zero latency scheduled gate per PHYSICAL qubit
+
 	
 	//the number of cycles until the specified physical qubit is available
 	inline int busyCycles(int physicalQubit) const {
-		auto & sg = this->lastGate[physicalQubit];
+		auto & sg = this->lastNonZeroLatencyGate[physicalQubit];
 		if(!sg) return 0;
 		int cycles = sg->cycle + sg->latency - this->cycle;
 		if(cycles < 0) return 0;


### PR DESCRIPTION
Previously, it was possible for two non-zero latency gates to clobber each other at the same cycle if a zero latency gate was scheduled between them.

This happened because scheduling a zero-latency gate on the same qubits as a previously scheduled non-zero-latency gate updates `Environment::lastGate`, which is used by `Node::busyCycles` to report for how long a qubit will be busy. To fix this, a separate `Environment::lastNonZeroLatencyGate` is maintained for the purpose of calculating busy cycles.