### PR TITLE
Bump max number of qubits to 127.

### DIFF
--- a/libtoqm/libtoqm/Node.hpp
+++ b/libtoqm/libtoqm/Node.hpp
@@ -18,7 +18,7 @@ class Environment;
 class Queue;
 
 //Warning: you may need to run make clean after changing MAX_QUBITS
-const int MAX_QUBITS = 20;
+const int MAX_QUBITS = 127;
 //extern int GLOBALCOUNTER;
 
 /**


### PR DESCRIPTION
Ultimately, we should still change this to be runtime sized instead. However, if bumping this up enables support for larger devices immediately without impacting circuit generation and without a big perf hit, let's do it.