### PR TITLE
Move initial_search_cycles to ToqmMapper constructor.

### DIFF
--- a/libtoqm/libtoqm/ToqmMapper.hpp
+++ b/libtoqm/libtoqm/ToqmMapper.hpp
@@ -41,6 +41,9 @@ public:
 	 * @param node_mods A sequence of `NodeMod` implementations.
 	 * @param filters A sequence of `Filter` implementations used to prune
 	 * redundant or otherwise uninteresting nodes from the search space.
+	 * @param initial_search_cycles If non-zero, uses this many cycles to find
+	 * an initial layout. If `-1`, uses the longest path between any two nodes
+	 * without going through any given node more than once.
 	 */
 	explicit ToqmMapper(
 			const Queue & node_queue,
@@ -48,7 +51,8 @@ public:
 			std::unique_ptr<CostFunc> cost_func,
 			std::unique_ptr<Latency> latency,
 			std::vector<std::unique_ptr<NodeMod>> node_mods,
-			std::vector<std::unique_ptr<Filter>> filters
+			std::vector<std::unique_ptr<Filter>> filters,
+			int initial_search_cycles
 	);
 	
 	/**
@@ -68,9 +72,8 @@ public:
 	
 	/**
 	 * Run the TOQM algorithm.
-	 * The initial layout is determined automatically using a cycle limit
-	 * equal to the diameter of the couping map, and is available in the
-	 * result.
+	 * If this instance was configured to perform layout, the determined
+	 * layout will be available in the result.
 	 * @param gates The topologically ordered gates that define the circuit.
 	 * @param num_qubits
 	 * @param coupling_map The coupling map describing the target hardware.
@@ -84,33 +87,18 @@ public:
 	run(const std::vector<GateOp> & gates, std::size_t num_qubits, const CouplingMap & coupling_map) const;
 	
 	/**
-	 * Run the TOQM algorithm.
-	 * The initial layout is determined automatically using the specified cycle limit,
-	 * and is available in the result.
-	 * @param gates
-	 * @param num_qubits
-	 * @param coupling_map
-	 * @param initial_search_cycles The number of cycles. If `-1`, uses the
-	 * longest path between any two nodes without going through any given node more
-	 * than once (this is a complete search and is the max value that can have an
-	 * effect).
-	 * @return
-	 */
-	std::unique_ptr<ToqmResult>
-	run(const std::vector<GateOp> & gates, std::size_t num_qubits, const CouplingMap & coupling_map, int initial_search_cycles) const;
-	
-	/**
 	 * Run the TOQM algorithm using the specified initial layout.
-	 * @param gates
+	 * If this instance was configured to perform layout, the layout
+	 * is determined using the specified initial layout as a starting point,
+	 * and will be available in the result.
+	 * @param gates The topologically ordered gates that define the circuit.
 	 * @param num_qubits
-	 * @param coupling_map
-	 * @param initial_search_cycles If non-zero, the initial layout is determined automatically
-	 * with `init_qal` as a starting point, using up to this many cycles.
-	 * @param init_qal
+	 * @param coupling_map The coupling map describing the target hardware.
+	 * @param init_qal An initial layout, mapping physical qubits to virtual.
 	 * @return
 	 */
 	std::unique_ptr<ToqmResult>
-	run(const std::vector<GateOp> & gates, std::size_t num_qubits, const CouplingMap & coupling_map, int initial_search_cycles, const std::vector<int> & init_qal) const;
+	run(const std::vector<GateOp> & gates, std::size_t num_qubits, const CouplingMap & coupling_map, const std::vector<int> & init_qal) const;
 
 private:
 	class Impl;

--- a/mapper/main.cpp
+++ b/mapper/main.cpp
@@ -462,7 +462,8 @@ int main(int argc, char ** argv) {
 			move(cf),
 			move(lat),
 			move(mods),
-			move(filters)));
+			move(filters),
+			initialSearchCycles));
 	
 	mapper->setRetainPopped(retainPopped);
 
@@ -494,7 +495,7 @@ int main(int argc, char ** argv) {
 	auto couplingMap = MapperUtils::parseCouplingMap(couplingMapFile);
 	
 	// invoke TOQM algo
-	auto result = mapper->run(qasm->gateOperations(), qasm->numQubits(), couplingMap, initialSearchCycles, init_qal);
+	auto result = mapper->run(qasm->gateOperations(), qasm->numQubits(), couplingMap, init_qal);
 	
 	// write new qasm to std::cout
 	qasm->toQasm2(std::cout, *result);

--- a/test/TestBenchmarks.cpp
+++ b/test/TestBenchmarks.cpp
@@ -54,7 +54,7 @@ TEST_CASE("Small circuits, IBM QX2, 1Q: 1 cycles, 2Q: 2 cycles, SWAP: 6 cycles",
 	auto coupling_map = MapperUtils::parseCouplingMap(coupling_istream);
 	auto circuit = MapperUtils::parseQasm2(circuit_istream);
 
-	auto mapper = toqm::test::MapperBuilder::forSmallCircuits().build();
+	auto mapper = toqm::test::MapperBuilder::forSmallCircuits(true).build();
 	auto result = mapper->run(circuit->gateOperations(), circuit->numQubits(), coupling_map);
 
 	std::stringstream outQasm {};
@@ -109,8 +109,8 @@ TEST_CASE("Large circuits, IBM Tokyo, 1Q: 1 cycles, 2Q: 2 cycles, SWAP: 6 cycles
 	auto coupling_map = MapperUtils::parseCouplingMap(coupling_istream);
 	auto circuit = MapperUtils::parseQasm2(circuit_istream);
 
-	auto mapper = toqm::test::MapperBuilder::forLargeCircuits().build();
-	auto result = mapper->run(circuit->gateOperations(), circuit->numQubits(), coupling_map, 0);
+	auto mapper = toqm::test::MapperBuilder::forLargeCircuits(false).build();
+	auto result = mapper->run(circuit->gateOperations(), circuit->numQubits(), coupling_map);
 
 	std::stringstream outQasm {};
 	circuit->toQasm2(outQasm, *result);

--- a/test/TestLatency.cpp
+++ b/test/TestLatency.cpp
@@ -59,11 +59,11 @@ TEST_CASE("Latency table can be configured to behave like simple latencies.", "[
 	REQUIRE(table->getLatency("cx", 2, -1, -1) == simple->getLatency("cx", 2, -1, -1));
 	REQUIRE(table->getLatency("swap", 2, -1, -1) == simple->getLatency("swap", 2, -1, -1));
 
-	auto simple_mapper = MapperBuilder::forSmallCircuits();
+	auto simple_mapper = MapperBuilder::forSmallCircuits(false);
 	simple_mapper.Latency = std::move(simple);
 	auto simple_result = simple_mapper.build()->run(gates, 7, coupling_map);
 
-	auto table_mapper = MapperBuilder::forSmallCircuits();
+	auto table_mapper = MapperBuilder::forSmallCircuits(false);
 	table_mapper.Latency = std::move(table);
 	auto table_result = table_mapper.build()->run(gates, 7, coupling_map);
 
@@ -93,10 +93,10 @@ TEST_CASE("Test 0-latency instructions work as expected.", "[latency]") {
 
 	auto table = std::unique_ptr<toqm::Latency>(new toqm::Table(latencies));
 
-	auto mapper = MapperBuilder::forSmallCircuits();
+	auto mapper = MapperBuilder::forSmallCircuits(false);
 	mapper.Latency = std::move(table);
 
-	auto result = mapper.build()->run(gates, coupling_map.numPhysicalQubits, coupling_map, 0);
+	auto result = mapper.build()->run(gates, coupling_map.numPhysicalQubits, coupling_map);
 
 	// Require order is the same, since this is the only valid ordering for this circuit.
 	REQUIRE(result->scheduledGates[0].gateOp.uid == 0);
@@ -133,10 +133,10 @@ TEST_CASE("Test 0-latency instructions at start of circuit.", "[latency]") {
 
 	auto table = std::unique_ptr<toqm::Latency>(new toqm::Table(latencies));
 
-	auto mapper = MapperBuilder::forSmallCircuits();
+	auto mapper = MapperBuilder::forSmallCircuits(false);
 	mapper.Latency = std::move(table);
 
-	auto result = mapper.build()->run(gates, coupling_map.numPhysicalQubits, coupling_map, 0);
+	auto result = mapper.build()->run(gates, coupling_map.numPhysicalQubits, coupling_map);
 
 	std::cout << result->scheduledGates;
 

--- a/test/util/MapperBuilder.cpp
+++ b/test/util/MapperBuilder.cpp
@@ -14,19 +14,21 @@ MapperBuilder::MapperBuilder() :
 	Filter1(nullptr),
 	Filter2(nullptr) {}
 
-MapperBuilder MapperBuilder::forSmallCircuits() {
+MapperBuilder MapperBuilder::forSmallCircuits(bool layout) {
 	MapperBuilder builder {};
 	builder.Filter1 = std::unique_ptr<toqm::Filter>(new toqm::HashFilter);
 	builder.Filter2 = std::unique_ptr<toqm::Filter>(new toqm::HashFilter2);
+	builder.InitialSearchCycles = layout ? -1 : 0;
 
 	return std::move(builder);
 }
 
-MapperBuilder MapperBuilder::forLargeCircuits() {
+MapperBuilder MapperBuilder::forLargeCircuits(bool layout) {
 	MapperBuilder builder {};
 	builder.Queue = std::unique_ptr<toqm::Queue>(new TrimSlowNodes(2000, 1000));
 	builder.Expander = std::unique_ptr<toqm::Expander>(new GreedyTopK(10));
 	builder.NodeMod = std::unique_ptr<toqm::NodeMod>(new toqm::GreedyMapper());
+	builder.InitialSearchCycles = layout ? -1 : 0;
 	builder.RetainPopped = 1;
 
 	return std::move(builder);
@@ -39,7 +41,8 @@ std::unique_ptr<toqm::ToqmMapper> MapperBuilder::build() {
 			this->CostFunc->clone(),
 			this->Latency->clone(),
 			this->NodeMods(),
-			this->Filters()));
+			this->Filters(),
+			this->InitialSearchCycles));
 
 	if (RetainPopped) {
 		mapper->setRetainPopped(RetainPopped);

--- a/test/util/MapperBuilder.hpp
+++ b/test/util/MapperBuilder.hpp
@@ -21,8 +21,8 @@ public:
 	MapperBuilder();
 	std::unique_ptr<toqm::ToqmMapper> build();
 
-	static MapperBuilder forSmallCircuits();
-	static MapperBuilder forLargeCircuits();
+	static MapperBuilder forSmallCircuits(bool layout);
+	static MapperBuilder forLargeCircuits(bool layout);
 
 	// Public fields to configure builder
 	std::unique_ptr<toqm::Queue> Queue;
@@ -32,6 +32,7 @@ public:
 	std::unique_ptr<toqm::NodeMod> NodeMod;
 	std::unique_ptr<toqm::Filter> Filter1;
 	std::unique_ptr<toqm::Filter> Filter2;
+	int InitialSearchCycles {};
 	int RetainPopped {};
 
 private:


### PR DESCRIPTION
This should make the code in qiskit-toqm a bit cleaner,
and seems like a more natural place for this option,
since it determines whether or not layout should be
performed by TOQM at all.