### PR TITLE
Throw exceptions for likely failures.

### DIFF
--- a/libtoqm/libtoqm/Expander/DefaultExpander.hpp
+++ b/libtoqm/libtoqm/Expander/DefaultExpander.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <iostream>
 #include <stdexcept>
+#include <sstream>
 
 namespace toqm {
 

--- a/libtoqm/libtoqm/Expander/DefaultExpander.hpp
+++ b/libtoqm/libtoqm/Expander/DefaultExpander.hpp
@@ -8,6 +8,7 @@
 #include <cassert>
 #include <vector>
 #include <iostream>
+#include <stdexcept>
 
 namespace toqm {
 
@@ -231,8 +232,12 @@ public:
 			//Reminder: this line caused problems when I tried placing it before looking at swaps
 			return true;
 		}
-		
-		assert(possibleGates.size() < 64); //or else I need to do this differently
+
+		if (possibleGates.size() >= 64) {
+			// TODO: modify approach to support >= 64 gates.
+			throw std::runtime_error("FATAL ERROR: current implementation cannot handle more than 63 possible gates.");
+		}
+
 		unsigned long long numIters = 1LL << possibleGates.size();
 		for(unsigned long long x = 0; x < numIters; x++) {
 			std::shared_ptr<Node> child = Node::prepChild(node.get());
@@ -241,9 +246,9 @@ public:
 			for(unsigned int y = 0; good && y < possibleGates.size(); y++) {
 				if(x & (1LL << y)) {
 					if(node->cycle >= -1) {
-						good = good && child->scheduleGate(possibleGates[y]);
+						good = child->scheduleGate(possibleGates[y]);
 					} else {//keha: should we assert that this is a swap gate?
-						good = good && child->swapQubits(possibleGates[y]->target, possibleGates[y]->control);
+						good = child->swapQubits(possibleGates[y]->target, possibleGates[y]->control);
 					}
 				}
 			}

--- a/libtoqm/libtoqm/Expander/GreedyTopK.hpp
+++ b/libtoqm/libtoqm/Expander/GreedyTopK.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <iostream>
 #include <queue>
+#include <stdexcept>
 
 namespace toqm {
 
@@ -275,7 +276,11 @@ public:
 		std::priority_queue<PriotityQueueType, std::vector<PriotityQueueType>, CmpNodeCost> tempNodes;
 		std::size_t numPushed = 0;
 		
-		assert(possibleGates.size() < 64); //or else I need to do this differently
+		if (possibleGates.size() >= 64) {
+			// TODO: modify approach to support >= 64 gates.
+			throw std::runtime_error("FATAL ERROR: current implementation cannot handle more than 63 possible gates.");
+		}
+
 		unsigned long long numIters = 1LL << possibleGates.size();
 		
 		for(unsigned long long x = 0; x < numIters; x++) {

--- a/libtoqm/libtoqm/Expander/GreedyTopK.hpp
+++ b/libtoqm/libtoqm/Expander/GreedyTopK.hpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <queue>
 #include <stdexcept>
+#include <sstream>
 
 namespace toqm {
 

--- a/libtoqm/libtoqm/Expander/NoSwaps.hpp
+++ b/libtoqm/libtoqm/Expander/NoSwaps.hpp
@@ -186,7 +186,8 @@ public:
 		//schedule the gates
 		for(auto & possibleGate : possibleGates) {
 			if(node->cycle >= -1) {
-				assert(child->scheduleGate(possibleGate));
+				auto res = child->scheduleGate(possibleGate);
+				assert(res);
 				numgatesscheduled++;
 			} else {
 				assert(false);

--- a/libtoqm/libtoqm/Node.cpp
+++ b/libtoqm/libtoqm/Node.cpp
@@ -6,6 +6,8 @@
 #include <cassert>
 #include <iostream>
 #include <string>
+#include <stdexcept>
+#include <sstream>
 
 namespace toqm {
 
@@ -171,10 +173,11 @@ void Node::scheduleGate(GateNode* gate, int physicalTarget, int physicalControl,
 	
 	if(!isSwap) {
 		if(this->readyGates.erase(gate) != 1) {
-			std::cerr << "FATAL ERROR: unable to remove scheduled gate from ready list.\n";
-			std::cerr << "\tGate name: " << gate->name << "\n";
-			std::cerr << "\tTime offset: " << timeOffset << "\n";
-			assert(false);
+			std::stringstream ss {};
+			ss << "FATAL ERROR: unable to remove scheduled gate from ready list.\n";
+			ss << "\tGate name: " << gate->name << "\n";
+			ss << "\tTime offset: " << timeOffset << "\n";
+			throw std::runtime_error(ss.str());
 		}
 		this->numUnscheduledGates--;
 	}


### PR DESCRIPTION
Previously, only `assert` was used, which isn't actually included when building with CMake Release settings. Many fatal errors now throw an `std::runtime_error`, which can be handled by `libtoqm` clients.